### PR TITLE
Update Android workflow compatible with latest sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ build.bat
 /build-*
 /captures
 .clangd
+.cache
 
 
 # assets

--- a/3rdparty/sokol/sokol_gfx.h
+++ b/3rdparty/sokol/sokol_gfx.h
@@ -5342,7 +5342,7 @@ _SOKOL_PRIVATE void _sg_gl_init_caps_gles3(void) {
                 _sg.gl.ext_anisotropic = true;
             }
             else if (strstr(ext, "_texture_sRGB")) {
-                _sg.gl.image_srgb = true;
+                // _sg.gl.image_srgb = true;
             }
         }
     }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.1)
 project(rizz)
 
+# generate compile_commands.json for clangd
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 if (ANDROID OR IOS)
     set(BUNDLE ON CACHE INTERNAL "Bundle mode" FORCE)
     set(BUILD_TOOLS OFF CACHE INTERNAL "Build tools" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ function(rizz__add_example proj_name)
     target_link_libraries(${proj_name} PRIVATE sx)
     add_dependencies(${proj_name} rizz)
 
-	IF (MSVC)
+	IF (MSVC AND NOT BUNDLE)
 		set_target_properties(${proj_name} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "$<TARGET_FILE_DIR:${proj_name}>/")
 		set_target_properties(${proj_name} PROPERTIES VS_DEBUGGER_COMMAND "rizz.exe")
 		set_target_properties(${proj_name} PROPERTIES VS_DEBUGGER_COMMAND_ARGUMENTS "--run ${proj_name}.dll")

--- a/cmake/bundle.cmake
+++ b/cmake/bundle.cmake
@@ -82,6 +82,7 @@ function(rizz_set_executable target_name)
         
         generate_bundle_file_internal("${plugins}" ${RIZZ_SOURCE_DIR}plugin_bundle.h 
                                       "rizz__plugin_bundle" ${internal_name})
+        target_sources(rizz PRIVATE ${RIZZ_SOURCE_DIR}plugin_bundle.h)
         target_link_libraries(${target_name} PRIVATE rizz)   # bundle mode always links with the rizz
         target_compile_definitions(${target_name} PRIVATE -DRIZZ_BUNDLE)
     elseif (plugins)

--- a/examples/07-nbody/nbody.c
+++ b/examples/07-nbody/nbody.c
@@ -96,8 +96,8 @@ static void load_particles(nbody_particle* particles, sx_vec3 center, sx_vec4 ve
 
 static bool init()
 {
-#if SX_PLATFORM_ANDROID
-    the_vfs->mount_android_assets("/assets");
+#if SX_PLATFORM_ANDROID || SX_PLATFORM_IOS
+    the_vfs->mount_mobile_assets("/assets");
 #else
     // mount `/asset` directory
     char asset_dir[RIZZ_MAX_PATH];

--- a/examples/08-draw3d/draw3d.c
+++ b/examples/08-draw3d/draw3d.c
@@ -105,8 +105,8 @@ static const rizz_model_geometry_layout k_stream_layout = {
 
 static bool init()
 {
-#if SX_PLATFORM_ANDROID
-    the_vfs->mount_android_assets("/assets");
+#if SX_PLATFORM_ANDROID || SX_PLATFORM_IOS
+    the_vfs->mount_mobile_assets("/assets");
 #else
     // mount `/asset` directory
     char asset_dir[RIZZ_MAX_PATH];

--- a/examples/09-pathfind/pathfind.c
+++ b/examples/09-pathfind/pathfind.c
@@ -195,8 +195,8 @@ static inline sx_vec2 random_pos()
 
 static bool init()
 {
-#if SX_PLATFORM_ANDROID
-    the_vfs->mount_android_assets("/assets");
+#if SX_PLATFORM_ANDROID || SX_PLATFORM_IOS
+    the_vfs->mount_mobile_assets("/assets");
 #else
     // mount `/asset` directory
     char asset_dir[RIZZ_MAX_PATH];

--- a/examples/11-pathspline/pathspline.c
+++ b/examples/11-pathspline/pathspline.c
@@ -147,8 +147,8 @@ static void cam_spline_eval(const rizz_spline3d_node* n1, const rizz_spline3d_no
 
 static bool init()
 {
-#if SX_PLATFORM_ANDROID
-    the_vfs->mount_android_assets("/assets");
+#if SX_PLATFORM_ANDROID || SX_PLATFORM_IOS
+    the_vfs->mount_mobile_assets("/assets");
 #else
     // mount `/asset` directory
     char asset_dir[RIZZ_MAX_PATH];

--- a/examples/12-boids/boids.c
+++ b/examples/12-boids/boids.c
@@ -239,8 +239,8 @@ void update_boid(int bi, float dt)
 
 static bool init()
 {
-#if SX_PLATFORM_ANDROID
-    the_vfs->mount_android_assets("/assets");
+#if SX_PLATFORM_ANDROID || SX_PLATFORM_IOS
+    the_vfs->mount_mobile_assets("/assets");
 #else
     // mount `/asset` directory
     char asset_dir[RIZZ_MAX_PATH];

--- a/include/rizz/android.h
+++ b/include/rizz/android.h
@@ -4,6 +4,7 @@
 
 #if SX_PLATFORM_ANDROID
 
+#    include "rizz/rizz.h"
 #    include <jni.h>
 
 typedef struct rizz_android_method {

--- a/scripts/build-tools/android.py
+++ b/scripts/build-tools/android.py
@@ -11,7 +11,7 @@
 # Arguments: see --help
 # Examples:
 # 1) prepare the '02-quad' example in `android/quad` directory, the package will be named 'com.glitterbombg.quad':
-#    ```python android.py --package com.glitterbombg.quad --name quad --cmake-target 02-quad --sdk-root=/path/to/android/sdk --target-dir=android/quad --cmake-source=/path/to/rizz configure```
+#    ```python android.py --package com.glitterbombg.quad --name quad --cmake-target 02-quad --plugins="imgui;basisut" --sdk-root=/path/to/android/sdk --target-dir=android/quad --cmake-source=/path/to/rizz configure```
 #    after successfully finished, you can browse the `android/quad` directory for generated files:
 #       - `apk` directory will contain native libraries, compiled java and assets. you can sync or copy 
 #         your assets into this folder
@@ -23,9 +23,9 @@
 #       - `AndroidManifest.xml` will be generated if you don't provide one, you can edit this file for your purposes
 #         But note that some arguments like `--sdk-min-platform-version`, `--sdk-platform-version` and `--app-version` will affect this file
 # 2) Build the binaries and java dex files
-#    ```python android.py --package com.glitterbombg.quad --name quad --cmake-target 02-quad --sdk-root=/path/to/android/sdk --target-dir=android/quad --cmake-source=/path/to/rizz build```
+#    ```python android.py --package com.glitterbombg.quad --name quad --cmake-target 02-quad --plugins="imgui;basisut" --sdk-root=/path/to/android/sdk --target-dir=android/quad --cmake-source=/path/to/rizz build```
 # 3) Make the final APK
-#    ```python android.py --package com.glitterbombg.quad --name quad --cmake-target 02-quad --sdk-root=d:/sdk/android --target-dir=android/quad --cmake-source=c:/projects/rizz --copy=/your/second/location package```
+#    ```python android.py --package com.glitterbombg.quad --name quad --cmake-target 02-quad --plugins="imgui;basisut" --sdk-root=d:/sdk/android --target-dir=android/quad --cmake-source=c:/projects/rizz --copy=/your/second/location package```
 #    Makes the final APK file, signs it (with debug key) and copy it to another location
 #    if you provide `--keystore`, `--key-alias`, `--keystore-password`, `--key-password` then it will signed by your custom key
 #

--- a/src/rizz/android.c
+++ b/src/rizz/android.c
@@ -1,14 +1,11 @@
-#include "rizz/android.h"
+#    include "rizz/android.h"
 
 #if SX_PLATFORM_ANDROID
-
-#    include "rizz/core.h"
-
 #    include "sx/string.h"
-
 #    include "android/native_activity.h"
 #    include <jni.h>
 #    include <pthread.h>
+#    include "internal.h"
 
 // app.c
 const void* sapp_android_get_native_activity(void);

--- a/src/rizz/app.c
+++ b/src/rizz/app.c
@@ -5,6 +5,7 @@
 
 #include "internal.h"
 
+#include "rizz/android.h"
 #include "rizz/ios.h"
 
 #include "sx/cmdline.h"

--- a/src/rizz/profiler.c
+++ b/src/rizz/profiler.c
@@ -11,6 +11,7 @@
 #include "sx/array.h"
 #include "sx/io.h"
 #include "sx/handle.h"
+#include "sx/macros.h"
 #include "sx/threads.h"
 #include "sx/string.h"
 #include "sx/os.h"
@@ -57,6 +58,8 @@ bool rizz__profile_init(const sx_alloc* alloc)
         g_profile.capture_context_handles = sx_handle_create_pool(g_profile.alloc, 16);
         if (!g_profile.capture_context_handles)
             return false;
+    #else
+        sx_unused(alloc);
     #endif
     return true;
 }

--- a/src/rizz/vfs.c
+++ b/src/rizz/vfs.c
@@ -12,6 +12,7 @@
 #include "sx/threads.h"
 
 #if SX_PLATFORM_ANDROID
+#    include "rizz/android.h"
 #    include <android/asset_manager.h>
 #    include <android/asset_manager_jni.h>
 #    include <jni.h>
@@ -280,6 +281,8 @@ static int rizz__vfs_worker(void* user)
 
 bool rizz__vfs_mount(const char* path, const char* alias, bool watch)
 {
+    sx_unused(watch);
+    
     if (sx_os_path_isdir(path)) {
         rizz__vfs_mount_point mp = { 0 };
         sx_os_path_normpath(mp.path, sizeof(mp.path), path);

--- a/src/utility/utility.c
+++ b/src/utility/utility.c
@@ -82,4 +82,9 @@ rizz_plugin_decl_main(utility, plugin, e)
     return 0;
 }
 
+rizz_plugin_decl_event_handler(utility, e)
+{
+    sx_unused(e);
+}
+
 rizz_plugin_implement_info(utility, 1000, "utility plugin", NULL, 0);


### PR DESCRIPTION
Hello, I modified some files to make `rizz` compatible with latest android sdks.

main changes:
- sdk-platform-version: 33
- NDK: 25.1
- replaced dx with d8
- add an argument `plugins` to list the plugins that is required by the application, separated by semicolon.



Tested on Android 12 & 13.
